### PR TITLE
Updated to current requirements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "django_socketio_test/gevent_socketio"]
 	path = gevent_socketio
-	url = git@github.com:shuoli84/gevent_socketio2.git
+	url = git@github.com:aarcro/gevent_socketio2.git

--- a/django_socketio_test/django_socketio_test/management/commands/run.py
+++ b/django_socketio_test/django_socketio_test/management/commands/run.py
@@ -1,13 +1,11 @@
 # coding=utf-8
-import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_socketio_test.settings")
 from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
         from django.core.wsgi import get_wsgi_application
+        from socketio.server import serve
+
         application = get_wsgi_application()
-        from socketio.server import SocketIOServer
-        server = SocketIOServer(('', 8001), application, resource="socket.io")
-        server.serve_forever()
+        serve(application, port=8001)

--- a/django_socketio_test/django_socketio_test/settings.py
+++ b/django_socketio_test/django_socketio_test/settings.py
@@ -22,8 +22,6 @@ SECRET_KEY = 'b#5hf$xowzmytc0srdo0wh=vm$stmx!wfw8=k3fd%gp(cd(mab'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
 ALLOWED_HOSTS = []
 
 
@@ -65,17 +63,37 @@ DATABASES = {
     }
 }
 
+# Template engines
+# https://docs.djangoproject.com/en/1.10/ref/templates/upgrading/
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug': DEBUG,
+            'context_processors': [
+                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                # list if you haven't customized them:
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.7/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
-
 TIME_ZONE = 'UTC'
-
 USE_I18N = True
-
 USE_L10N = True
-
 USE_TZ = True
 
 

--- a/django_socketio_test/django_socketio_test/urls.py
+++ b/django_socketio_test/django_socketio_test/urls.py
@@ -1,17 +1,14 @@
 from __future__ import absolute_import
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import TemplateView
-from socketio.sdjango import urls
+from socketio import sdjango
 
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'django_socketio_test.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
 
+urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='index.html')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^socket\.io/', include(urls)),
-) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    url(r'^socket\.io/', include(sdjango)),
+]  + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/django_socketio_test/requirements.txt
+++ b/django_socketio_test/requirements.txt
@@ -1,10 +1,11 @@
-Django==1.7
-WebOb==1.4
-django-extensions==1.4.0
-gevent==1.0.1
+Django==1.10.4
+django-extensions==1.7.5
+gevent==1.2.0
+-e git+git@github.com:aarcro/gevent_socketio2.git@bfceec47999801538a5737bb04a13b95ea13e8cf#egg=gevent_socketio2&subdirectory=../../../gevent_socketio
 gevent-websocket==0.9.3
 greenlet==0.4.4
-pyee==0.1.0
+pyee==3.0.1
 requests==2.4.1
-wsgiref==0.1.2
-gevent_socketio2==0.1.2
+six==1.10.0
+WebOb==1.4
+ws4py==0.3.4

--- a/django_socketio_test/requirements.txt
+++ b/django_socketio_test/requirements.txt
@@ -1,7 +1,7 @@
 Django==1.10.4
 django-extensions==1.7.5
 gevent==1.2.0
--e git+git@github.com:aarcro/gevent_socketio2.git@bfceec47999801538a5737bb04a13b95ea13e8cf#egg=gevent_socketio2&subdirectory=../../../gevent_socketio
+-e git+git@github.com:aarcro/gevent_socketio2.git@bfceec47999801538a5737bb04a13b95ea13e8cf#egg=gevent_socketio2
 gevent-websocket==0.9.3
 greenlet==0.4.4
 pyee==3.0.1


### PR DESCRIPTION
Now runs on Django 1.10, socket.io 1.4 and updates of other required libraries.

Depends on the changes in aarcro/gevent_socketio2.git